### PR TITLE
Add profile setup screen for Google OAuth users and commands reference

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,0 +1,31 @@
+# Commands Reference
+
+## Install
+```bash
+npm install
+```
+
+## API (apps/api)
+```bash
+npm -w @bitebuddy/api run dev        # Dev server → http://localhost:3000
+npm -w @bitebuddy/api run build      # Production build
+npm -w @bitebuddy/api run lint       # Lint
+```
+
+## Mobile (apps/mobile)
+```bash
+npm -w @bitebuddy/mobile start       # Expo dev server (press i for iOS, a for Android)
+npm -w @bitebuddy/mobile run ios     # iOS simulator
+npm -w @bitebuddy/mobile run android # Android emulator
+```
+
+## Adding Packages
+```bash
+npx expo install <pkg> --project apps/mobile   # Expo-compatible package
+npm -w @bitebuddy/api install <pkg>             # API package
+```
+
+## Local Dev Setup
+1. Start API: `npm -w @bitebuddy/api run dev`
+2. Start Mobile: `npm -w @bitebuddy/mobile start`
+3. Ensure `apps/mobile/.env` has `EXPO_PUBLIC_API_URL=http://localhost:3000`

--- a/apps/api/src/app/api/profile/route.ts
+++ b/apps/api/src/app/api/profile/route.ts
@@ -9,6 +9,20 @@ export async function PUT(request: NextRequest) {
 
   const body: UpdateProfileRequest = await request.json();
   const updates: Record<string, string | undefined> = {};
+
+  if (body.username !== undefined) {
+    // Only allow setting username if current one is a placeholder
+    const { data: currentProfile } = await supabase
+      .from('profiles')
+      .select('username')
+      .eq('id', user.id)
+      .single();
+
+    if (currentProfile && currentProfile.username.startsWith('user_')) {
+      updates.username = body.username;
+    }
+  }
+
   if (body.display_name !== undefined) updates.display_name = body.display_name;
   if (body.avatar_url !== undefined) updates.avatar_url = body.avatar_url;
 

--- a/apps/mobile/app/(auth)/profile-setup.tsx
+++ b/apps/mobile/app/(auth)/profile-setup.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import {
+  View, Text, TextInput, TouchableOpacity, StyleSheet,
+  KeyboardAvoidingView, Platform,
+} from 'react-native';
+import { useAuth } from '../../contexts/AuthContext';
+import { apiPut } from '../../lib/api';
+import type { UpdateProfileRequest } from '@bitebuddy/shared';
+
+export default function ProfileSetupScreen() {
+  const { user, profile, refreshProfile } = useAuth();
+  const [username, setUsername] = useState('');
+  const [displayName, setDisplayName] = useState(
+    () => user?.user_metadata?.full_name ?? profile?.display_name ?? ''
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSave() {
+    setError('');
+    const trimmed = username.trim().toLowerCase();
+    if (!trimmed) {
+      setError('Username is required');
+      return;
+    }
+    if (trimmed.length < 3) {
+      setError('Username must be at least 3 characters');
+      return;
+    }
+    if (!/^[a-z0-9_]+$/.test(trimmed)) {
+      setError('Username can only contain letters, numbers, and underscores');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const body: UpdateProfileRequest = { username: trimmed };
+      if (displayName.trim()) {
+        body.display_name = displayName.trim();
+      }
+      await apiPut('/api/profile', body);
+      await refreshProfile();
+    } catch (err: any) {
+      setError(err.message || 'Could not save profile');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <View style={styles.inner}>
+        <Text style={styles.title}>Welcome!</Text>
+        <Text style={styles.subtitle}>Choose a username to get started</Text>
+
+        {error ? (
+          <View style={styles.errorBox}>
+            <Text style={styles.errorText}>{error}</Text>
+          </View>
+        ) : null}
+
+        <TextInput
+          style={styles.input}
+          placeholder="Username"
+          placeholderTextColor="#999"
+          value={username}
+          onChangeText={setUsername}
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Display Name (optional)"
+          placeholderTextColor="#999"
+          value={displayName}
+          onChangeText={setDisplayName}
+        />
+
+        <TouchableOpacity
+          style={[styles.button, loading && styles.buttonDisabled]}
+          onPress={handleSave}
+          disabled={loading}
+        >
+          <Text style={styles.buttonText}>
+            {loading ? 'Saving...' : 'Continue'}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  inner: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: '800',
+    color: '#FF6B35',
+    textAlign: 'center',
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#888',
+    textAlign: 'center',
+    marginBottom: 40,
+  },
+  input: {
+    backgroundColor: '#f5f5f5',
+    borderRadius: 12,
+    padding: 16,
+    fontSize: 16,
+    marginBottom: 12,
+    color: '#1a1a1a',
+  },
+  button: {
+    backgroundColor: '#FF6B35',
+    borderRadius: 12,
+    padding: 16,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  errorBox: {
+    backgroundColor: '#FFE8E0',
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: '#FF6B35',
+  },
+  errorText: {
+    color: '#CC3300',
+    fontSize: 14,
+    textAlign: 'center',
+    fontWeight: '500',
+  },
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -3,7 +3,7 @@ import { Slot, useRouter, useSegments } from 'expo-router';
 import { AuthProvider, useAuth } from '../contexts/AuthContext';
 
 function AuthGate() {
-  const { session, loading } = useAuth();
+  const { session, loading, needsProfileSetup } = useAuth();
   const segments = useSegments();
   const router = useRouter();
 
@@ -13,10 +13,14 @@ function AuthGate() {
 
     if (!session && !inAuthGroup) {
       router.replace('/(auth)/login');
+    } else if (session && needsProfileSetup) {
+      if (segments.join('/') !== '(auth)/profile-setup') {
+        router.replace('/(auth)/profile-setup');
+      }
     } else if (session && inAuthGroup) {
       router.replace('/(tabs)');
     }
-  }, [session, loading, segments]);
+  }, [session, loading, needsProfileSetup, segments]);
 
   if (loading) return null;
 

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -13,6 +13,7 @@ interface AuthState {
   user: User | null;
   profile: Profile | null;
   loading: boolean;
+  needsProfileSetup: boolean;
   signIn: (email: string, password: string) => Promise<void>;
   signUp: (email: string, password: string, username: string) => Promise<void>;
   signInWithGoogle: () => Promise<void>;
@@ -131,6 +132,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         user: session?.user ?? null,
         profile,
         loading,
+        needsProfileSetup: !!profile && profile.username.startsWith('user_'),
         signIn,
         signUp,
         signInWithGoogle,

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -21,6 +21,7 @@ export interface AuthResponse {
 
 // Profile
 export interface UpdateProfileRequest {
+  username?: string;
   display_name?: string;
   avatar_url?: string;
 }

--- a/supabase/migrations/001_create_profiles.sql
+++ b/supabase/migrations/001_create_profiles.sql
@@ -18,8 +18,8 @@ begin
   insert into public.profiles (id, username, display_name)
   values (
     new.id,
-    new.raw_user_meta_data->>'username',
-    coalesce(new.raw_user_meta_data->>'display_name', new.raw_user_meta_data->>'username')
+    coalesce(new.raw_user_meta_data->>'username', 'user_' || substr(new.id::text, 1, 8)),
+    coalesce(new.raw_user_meta_data->>'display_name', new.raw_user_meta_data->>'full_name', 'New User')
   );
   return new;
 end;


### PR DESCRIPTION
Google OAuth users get a placeholder username via updated DB trigger, then are routed to a profile-setup screen to choose their username before entering the app. Also adds COMMANDS.md for quick reference.